### PR TITLE
Spacemacs once

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,22 @@
 ![Desktop](https://github.com/da-edra/dotfiles/blob/master/.screenshots/desktop.png)
 
 ```
-       __      __  _____ __         
+       __      __  _____ __
   ____/ /___  / /_/ __(_) /__  _____
  / __  / __ \/ __/ /_/ / / _ \/ ___/
-/ /_/ / /_/ / /_/ __/ / /  __(__  ) 
-\__,_/\____/\__/_/ /_/_/\___/____/  
-             __                     
-            / /_  __  __            
-           / __ \/ / / /            
-          / /_/ / /_/ /             
-         /_.___/\__, /              
-               /____/               
-                   __               
+/ /_/ / /_/ / /_/ __/ / /  __(__  )
+\__,_/\____/\__/_/ /_/_/\___/____/
+             __
+            / /_  __  __
+           / __ \/ / / /
+          / /_/ / /_/ /
+         /_.___/\__, /
+               /____/
+                   __
   ____ _____  ____/ /_______  ____ _
  / __ `/ __ \/ __  / ___/ _ \/ __ `/
-/ /_/ / / / / /_/ / /  /  __/ /_/ / 
-\__,_/_/ /_/\__,_/_/   \___/\__,_/  
+/ /_/ / / / / /_/ / /  /  __/ /_/ /
+\__,_/_/ /_/\__,_/_/   \___/\__,_/
 ```
 
 ![forthebadge](https://forthebadge.com/images/badges/built-with-love.svg)
@@ -46,7 +46,7 @@ I'm including some screenshots on this repo and a list of dependencies in case y
 | acpi                                                     | To monitor the battery status                                    |
 | [neofetch](https://github.com/dylanaraps/neofetch)       | A fast, highly customizable system info script                   |
 | [Nerd Fonts](https://github.com/ryanoasis/nerd-fonts)    | Fonts patched with lots of amazing icons (I use Source Code Pro) |
- 
+
 ------
 
 **For the window manager:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-### Arch Linux [i3-gaps + i3blocks + Zsh + Spacemacs + Rofi + Neofetch + Spacemacs]
+### Arch Linux [i3-gaps + i3blocks + Zsh + Spacemacs + Rofi + Neofetch]
 
 ![Desktop](https://github.com/da-edra/dotfiles/blob/master/.screenshots/desktop.png)
 


### PR DESCRIPTION
Hi,

Thanks for sharing your dotfiles, the screenshots looks great! I want to try them out some day.

The README file mentions `Spacemacs` twice in the title. I'm not sure if it is on purpose or not, but this is a pull request for keeping just one of them. My editor is configured to remove trailing spaces, so they were also removed in the process.

Accept or reject at will.

Best regards,
Alexander F. Rødseth