### PR TITLE
Move environment variables to zshenv

### DIFF
--- a/zprofile
+++ b/zprofile
@@ -1,30 +1,3 @@
-# Enviroment variables
-export ZSH="/home/andrea/.oh-my-zsh"
-export LC_ALL=en_US.UTF-8
-export TERMINAL=alacritty
-export PAGER=less
-export VISUAL=emacs
-export TERM="xterm-256color"
-export GPG_TTY=$(tty)
-export LESS_TERMCAP_md=$'\e[1;36m'
-export LESS_TERMCAP_me=$'\e[0m'
-export LESS_TERMCAP_se=$'\e[0m'
-export LESS_TERMCAP_so=$'\e[1;33m'
-export LESS_TERMCAP_ue=$'\e[0m'
-export LESS_TERMCAP_us=$'\e[1;4;31m'
-export EDITOR='emacs'
-export RANGER_LOAD_DEFAULT_RC=FALSE
-
-# Node.js
-PATH="$HOME/.node_modules/bin:$PATH"
-export npm_config_prefix=~/.node_modules
-
-# PIP
-export PATH=$HOME/.local/bin:$PATH
-
-# Go
-export PATH="$PATH:$HOME/go/bin"
-
 # startx when logged in
 if [[ ! $DISPLAY && $XDG_VTNR -eq 1 ]]; then
     exec ssh-agent startx

--- a/zshenv
+++ b/zshenv
@@ -1,0 +1,25 @@
+export ZSH="/home/andrea/.oh-my-zsh"
+export LC_ALL=en_US.UTF-8
+export TERMINAL=alacritty
+export PAGER=less
+export VISUAL=emacs
+export TERM="xterm-256color"
+export GPG_TTY=$(tty)
+export LESS_TERMCAP_md=$'\e[1;36m'
+export LESS_TERMCAP_me=$'\e[0m'
+export LESS_TERMCAP_se=$'\e[0m'
+export LESS_TERMCAP_so=$'\e[1;33m'
+export LESS_TERMCAP_ue=$'\e[0m'
+export LESS_TERMCAP_us=$'\e[1;4;31m'
+export EDITOR='emacs'
+export RANGER_LOAD_DEFAULT_RC=FALSE
+
+# Node.js
+PATH="$HOME/.node_modules/bin:$PATH"
+export npm_config_prefix=~/.node_modules
+
+# PIP
+export PATH=$HOME/.local/bin:$PATH
+
+# Go
+export PATH="$PATH:$HOME/go/bin"


### PR DESCRIPTION
This is just a suggestion that would follow written conventions moreso and help organization a little bit. For a brief explaination on why one would do this, see [this question on StackExchange](https://unix.stackexchange.com/a/71258).

P.S. I know these are your personal dotfiles and they're yours to configure, I just thought this might be a welcome amendment 😁.